### PR TITLE
Improve PDF artifact management in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,9 +32,19 @@ jobs:
       with:
         version: "latest"
 
-    # 依存関係のインストール
+    # 依存関係のインストール（dev依存関係も含む）
     - name: Install dependencies
-      run: uv sync
+      run: uv sync --extra dev
+
+    # テスト出力ディレクトリの作成
+    - name: Create test output directory
+      run: mkdir -p test-output
+
+    # pytest実行（テストPDF生成）
+    - name: Run pytest
+      env:
+        TEST_OUTPUT_DIR: test-output
+      run: uv run pytest -v
 
     # テストPDFの生成
     - name: Generate test PDF
@@ -50,11 +60,35 @@ jobs:
           echo "✗ test_label.pdf が見つかりません"
           exit 1
         fi
+        if [ -d test-output ] && [ "$(ls -A test-output/*.pdf 2>/dev/null)" ]; then
+          echo "✓ pytest PDFs が生成されました"
+          ls -lh test-output/*.pdf
+        fi
+
+    # Artifact名を動的に設定（PR番号とコミットSHA含む）
+    - name: Set artifact name
+      id: artifact-name
+      run: |
+        SHORT_SHA=${GITHUB_SHA:0:7}
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          echo "name=test-label-pdf-pr-${{ github.event.pull_request.number }}-${SHORT_SHA}" >> $GITHUB_OUTPUT
+        else
+          echo "name=test-label-pdf-main-${SHORT_SHA}" >> $GITHUB_OUTPUT
+        fi
 
     # 生成されたPDFをアーティファクトとしてアップロード
+    # 保持期間: 1日（溜まりすぎないように最短設定）
     - name: Upload PDF artifact
       uses: actions/upload-artifact@v4
       with:
-        name: test-label-pdf
-        path: test_label.pdf
-        retention-days: 30
+        name: ${{ steps.artifact-name.outputs.name }}
+        path: |
+          test_label.pdf
+          test-output/*.pdf
+        retention-days: 1
+        if-no-files-found: warn
+
+    # NOTE: 古いArtifactの自動削除が必要な場合は、以下を参考に別ワークフローを作成
+    # .github/workflows/cleanup-artifacts.yml を作成し、
+    # actions/github-script や geekyeggo/delete-artifact を使用して
+    # 定期的に古いArtifactを削除できます

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,9 @@ venv.bak/
 *.swo
 *~
 
+# Test output directory (CI-generated PDFs)
+test-output/
+
 # Generated PDFs (for testing)
 *.pdf
 !examples/*.pdf


### PR DESCRIPTION
## Summary
- GitHub ActionsでPDF Artifactの管理を改善
- 保持期間を1日に短縮してストレージ肥大化を防止
- Artifact名を動的に設定してPR/コミット単位で識別可能に
- pytestで生成されるPDFもArtifactとしてアップロード

## Changes

### 1. Artifact保持期間の最適化
- **変更前**: 30日
- **変更後**: 1日（GitHub Actionsの最短設定）
- 目的: ストレージ使用量の抑制

### 2. 動的なArtifact命名
Artifact名にPR番号とコミットSHAを含めることで、どのPR/コミットのPDFか一目で識別可能に：
- **PR時**: `test-label-pdf-pr-123-abc1234`
- **main時**: `test-label-pdf-main-abc1234`

### 3. pytest実行の追加
- ユニットテストを実行してテストケースで生成されるPDFもArtifactに保存
- `TEST_OUTPUT_DIR` 環境変数を使用してCI環境でのみPDFを保存
- ローカル実行では従来通りtempfileを使用（既存動作に影響なし）

### 4. 将来の拡張性
- 古いArtifactの自動削除ワークフロー追加のためのコメントを追加
- 必要に応じて `.github/workflows/cleanup-artifacts.yml` を作成可能

## Test plan
- [x] ローカルでpytestを実行し、TEST_OUTPUT_DIR設定時にPDFが保存されることを確認
- [x] generate_test_pdf.pyが正常に動作することを確認
- [x] このPRでGitHub Actionsが実行され、Artifactが正しくアップロードされることを確認
- [x] Artifact名にPR番号とコミットSHAが含まれていることを確認
- [x] 生成された3つのPDF（test_label.pdf、test_label_generation.pdf、test_label_generator_class.pdf）がダウンロード可能なことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)