### PR TITLE
Move hardcoded secret key to environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Flask Secret Key
+# 本番環境では必ず設定してください
+# 例: openssl rand -hex 32 でランダムキーを生成できます
+SECRET_KEY=your-secret-key-here

--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ uv run python -m letterpack.web
 # ブラウザで http://localhost:5000 を開く
 ```
 
+#### 環境変数の設定
+
+本番環境でWebインターフェースを使用する場合は、セキュリティのために `SECRET_KEY` 環境変数を設定してください：
+
+```bash
+# シークレットキーを生成（例）
+export SECRET_KEY=$(openssl rand -hex 32)
+
+# または .env ファイルを作成
+cp .env.example .env
+# .env ファイルを編集して SECRET_KEY を設定
+
+# Webサーバーを起動
+uv run python -m letterpack.web
+```
+
+開発環境では環境変数が未設定でも動作しますが、警告が表示されます。
+
 ## 必要な情報
 
 - **お届け先**

--- a/src/letterpack/label.py
+++ b/src/letterpack/label.py
@@ -61,7 +61,7 @@ class LabelGenerator:
 
         # デフォルトフォント: ReportLabのCJKフォントを登録
         try:
-            pdfmetrics.registerFont(UnicodeCIDFont('HeiseiKakuGo-W5'))
+            pdfmetrics.registerFont(UnicodeCIDFont("HeiseiKakuGo-W5"))
             self.font_name = "HeiseiKakuGo-W5"
         except Exception as e:
             print(f"警告: HeiseiKakuGo-W5の登録に失敗しました: {e}")

--- a/src/letterpack/web.py
+++ b/src/letterpack/web.py
@@ -3,6 +3,7 @@ Webインターフェース (Flask)
 """
 
 import os
+import sys
 import tempfile
 
 from flask import Flask, flash, redirect, render_template_string, request, send_file, url_for
@@ -10,7 +11,20 @@ from flask import Flask, flash, redirect, render_template_string, request, send_
 from .label import AddressInfo, create_label
 
 app = Flask(__name__)
-app.secret_key = os.urandom(24)
+
+# 環境変数からシークレットキーを取得
+# 本番環境では必ず SECRET_KEY 環境変数を設定してください
+secret_key = os.environ.get("SECRET_KEY")
+if not secret_key:
+    print(
+        "警告: SECRET_KEY 環境変数が設定されていません。",
+        "開発用のランダムキーを使用します。",
+        "本番環境では必ず SECRET_KEY を設定してください。",
+        file=sys.stderr,
+    )
+    secret_key = os.urandom(24)
+
+app.secret_key = secret_key
 
 
 # HTMLテンプレート


### PR DESCRIPTION
- SECRET_KEY環境変数からFlaskのシークレットキーを読み込むように変更
- 環境変数が未設定の場合は警告を表示して開発用のランダムキーを使用
- .env.exampleファイルを追加して環境変数の設定例を提供
- READMEに環境変数の設定方法を追加
- 本番環境でのセキュリティが向上

セキュリティの改善により、アプリの再起動時もセッションが維持され、
複数ワーカーでの運用も可能になります。