### PR TITLE
Fix duplicate Claude review execution issue

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,9 +13,9 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude review')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude review')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '@claude review')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
@claude reviewコメントに対してclaudeワークフローが実行されないように修正。
これにより、claude-code-review.ymlのみが実行されるようになり、重複が解消される。

変更内容:
- claude.ymlの条件に`!contains(..., '@claude review')`を追加
- issue_comment、pull_request_review_comment、pull_request_reviewイベントに対して適用

これで以下のように動作する:
- `@claude review` → claude-code-review.ymlのみ実行
- `@claude` (その他) → claude.ymlのみ実行