### PR TITLE
ラベル項目名を一般的なラベルシール形式に変更

### DIFF
--- a/src/letterpack/label.py
+++ b/src/letterpack/label.py
@@ -439,10 +439,10 @@ class LabelGenerator:
         postal_box_offset_y = self.config.spacing.postal_box_offset_y
         dotted_line_text_offset = self.config.spacing.dotted_line_text_offset
 
-        # おところ:
+        # 郵便番号（〒記号付き）
         c.setFont(self.font_name, label_font_size)
         c.setFillColorRGB(0, 0, 0)
-        c.drawString(x + margin, current_y, "おところ:")
+        c.drawString(x + margin, current_y, "〒")
 
         current_y -= section_spacing
 
@@ -477,13 +477,6 @@ class LabelGenerator:
 
         current_y -= address_name_gap
 
-        # おなまえ:
-        c.setFont(self.font_name, label_font_size)
-        c.setFillColorRGB(0, 0, 0)
-        c.drawString(x + margin, current_y, "おなまえ:")
-
-        current_y -= section_spacing
-
         # 名前記入エリア（点線を短くして「様」のスペースを確保）
         sama_width = self.config.sama.width * mm
         name_line_end = x + width - margin - sama_width
@@ -504,10 +497,10 @@ class LabelGenerator:
 
         current_y -= name_phone_gap
 
-        # 電話番号:
+        # Tel.
         c.setFont(self.font_name, label_font_size)
         c.setFillColorRGB(0, 0, 0)
-        c.drawString(x + margin, current_y, "電話番号:")
+        c.drawString(x + margin, current_y, "Tel.")
 
         current_y -= section_spacing
 


### PR DESCRIPTION
## Summary
- ラベルから英語表記を削除（Address, Name, Telephone Number）
- 「おところ:」を削除し、郵便番号の前に「〒」記号を表示
- 「おなまえ:」を削除
- 「電話番号:」を「Tel.」に短縮

一般的な市販のラベルシールに近い、シンプルで見やすい表記に統一しました。

## 変更内容
- src/letterpack/label.py: ラベル項目名の表記を変更

## Test plan
- [x] テストが全て通過することを確認
- [x] Ruffによるコードチェックとフォーマットを実施
- [x] 実際にPDFを生成して視覚的に確認