### PR TITLE
Fix address field line height spacing

### DIFF
--- a/src/letterpack/label.py
+++ b/src/letterpack/label.py
@@ -67,7 +67,7 @@ class SpacingConfig(BaseModel):
     """要素間のスペーシング設定"""
 
     section_spacing: int = Field(default=15, ge=0, le=100, description="セクション間の間隔 (px)")
-    address_line_height: int = Field(default=12, ge=0, le=100, description="住所の行間 (px)")
+    address_line_height: int = Field(default=18, ge=0, le=100, description="住所の行間 (px)")
     address_name_gap: int = Field(
         default=8, ge=0, le=100, description="住所と名前セクションの間隔 (px)"
     )


### PR DESCRIPTION
フォントサイズ11ptに対して行間が狭かったため、
より読みやすく記入しやすい高さに調整。
4行分の記入スペースが適切に確保されるようになる。