### PR TITLE
Adjust spacing for address and name fields

### DIFF
--- a/src/letterpack/label.py
+++ b/src/letterpack/label.py
@@ -81,7 +81,7 @@ class SpacingConfig(BaseModel):
         default=-2, ge=-100, le=100, description="郵便番号ボックスのY軸オフセット (px)"
     )
     dotted_line_text_offset: int = Field(
-        default=2, ge=0, le=50, description="点線からテキストまでのオフセット (px)"
+        default=4, ge=0, le=50, description="点線からテキストまでのオフセット (px)"
     )
 
 


### PR DESCRIPTION
## Summary
- 住所と名前のテキストを罫線から2ポイント上に移動し、より読みやすいレイアウトに調整

## Changes
- `dotted_line_text_offset`のデフォルト値を2から4に変更
- 住所（複数行）、名前、「様」の表示位置が罫線から2ポイント上に移動

## Test plan
- [x] すべてのテスト（13件）が通過
- [x] リントチェック・フォーマットチェックが通過
- [x] 生成されたPDFを目視で確認し、テキストと罫線の間隔が適切か確認