### PR TITLE
Increase phone number font size

### DIFF
--- a/config/label_layout.yaml
+++ b/config/label_layout.yaml
@@ -14,7 +14,7 @@ fonts:
   postal_code: 10  # 郵便番号
   address: 11  # 住所
   name: 14  # 氏名
-  phone: 11  # 電話番号
+  phone: 10  # 電話番号（郵便番号と同じサイズに調整）
 
 # 要素間のスペーシング（px単位）
 spacing:

--- a/src/letterpack/label.py
+++ b/src/letterpack/label.py
@@ -61,7 +61,7 @@ class FontsConfig(BaseModel):
     postal_code: int = Field(default=13, gt=0, le=72, description="郵便番号のフォントサイズ (pt)")
     address: int = Field(default=11, gt=0, le=72, description="住所のフォントサイズ (pt)")
     name: int = Field(default=14, gt=0, le=72, description="氏名のフォントサイズ (pt)")
-    phone: int = Field(default=11, gt=0, le=72, description="電話番号のフォントサイズ (pt)")
+    phone: int = Field(default=13, gt=0, le=72, description="電話番号のフォントサイズ (pt)")
 
 
 class SpacingConfig(BaseModel):

--- a/tests/test_label.py
+++ b/tests/test_label.py
@@ -128,7 +128,7 @@ def test_load_default_config():
     assert config.fonts.postal_code == 13
     assert config.fonts.address == 11
     assert config.fonts.name == 14
-    assert config.fonts.phone == 11
+    assert config.fonts.phone == 13
     assert config.postal_box.line_width == 0.5
     assert config.postal_box.text_vertical_offset == 2
     assert config.spacing.postal_box_offset_y == -2


### PR DESCRIPTION
- デフォルト設定で電話番号のフォントサイズを11ptから13ptに変更
- YAMLの設定では郵便番号（10pt）と同じサイズに調整
- テストケースを更新して新しいサイズを反映