### PR TITLE
Set up GitHub Pages with Actions

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,68 @@
+name: Deploy to GitHub Pages
+
+# ワークフローのトリガー設定
+on:
+  # mainブランチへのpush時に実行
+  push:
+    branches: [ main ]
+    paths:
+      - 'index_static.html'
+      - 'poc_pyodide.html'
+      - 'STATIC_VERSION.md'
+      - 'README.md'
+  # 手動実行も可能
+  workflow_dispatch:
+
+# GitHub Pagesへのデプロイに必要な権限設定
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# 同時実行の制御（複数のデプロイが同時に実行されないようにする）
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # 静的コンテンツをビルド（準備）するジョブ
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Create deployment directory
+        run: |
+          mkdir -p _site
+          cp index_static.html _site/index.html
+          cp poc_pyodide.html _site/poc_pyodide.html
+          cp STATIC_VERSION.md _site/STATIC_VERSION.md
+          cp README.md _site/README.md
+          echo "✅ デプロイ用ファイルを準備しました"
+          ls -la _site/
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '_site'
+
+  # GitHub Pagesへデプロイするジョブ
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+      - name: Show deployment URL
+        run: |
+          echo "🚀 デプロイ完了!"
+          echo "📄 公開URL: ${{ steps.deployment.outputs.page_url }}"

--- a/README.md
+++ b/README.md
@@ -121,14 +121,37 @@ python -m http.server 8000
 - ✅ **Noto Sans JP使用**: Google Fontsから高品質な日本語フォントを自動ダウンロード
 - ⚠️ **初回ロードが遅い**: Pyodide + フォントのダウンロード（約12MB）に時間がかかる
 
-#### GitHub Pagesで公開する
+#### GitHub Pagesで公開する（自動デプロイ）⭐ 推奨
 
-```bash
-# リポジトリのSettingsから GitHub Pages を有効化
-# Source: Deploy from a branch
-# Branch: main (または別のブランチ)
-# 公開URL: https://yourusername.github.io/letter-pack-label-maker/index_static.html
+このリポジトリには **GitHub Actions による自動デプロイ**が設定されています。
+
+##### 初回セットアップ
+
+1. リポジトリのSettings → Pages を開く
+2. **Source** を「**GitHub Actions**」に変更
+3. mainブランチにpushすると自動的にデプロイされます
+
+##### 自動デプロイの仕組み
+
+- mainブランチへのpush時に自動実行（`.github/workflows/deploy-pages.yml`）
+- `index_static.html` が公開URLのルート (`/`) にデプロイされます
+- 変更対象: `index_static.html`, `poc_pyodide.html`, `STATIC_VERSION.md`, `README.md`
+
+##### 公開URL
+
 ```
+https://yourusername.github.io/letter-pack-label-maker/
+```
+
+**アクセス可能なページ:**
+- `/` - メインのラベル作成UI（`index_static.html`）
+- `/poc_pyodide.html` - PyodideのPoC版
+- `/STATIC_VERSION.md` - 静的版のドキュメント
+- `/README.md` - プロジェクトREADME
+
+##### 手動デプロイ
+
+GitHub Actionsページから手動でワークフローを実行することも可能です。
 
 ### Docker環境での実行
 


### PR DESCRIPTION
- `.github/workflows/deploy-pages.yml` を追加
  - mainブランチへのpush時に自動デプロイ
  - 手動デプロイにも対応
  - index_static.html をルート (/) にデプロイ

- README.md を更新
  - GitHub Pages自動デプロイの使用方法を追加
  - 初回セットアップ手順を明記
  - 公開URLとアクセス可能なページを説明