### PR TITLE
Add CSV download with headers and samples

### DIFF
--- a/index_static.html
+++ b/index_static.html
@@ -250,6 +250,12 @@
             </form>
 
             <div id="csv-form-container" style="display:none; margin-top: 50px; padding-top: 40px; border-top: 2px solid #e0e0e0;">
+                <div style="text-align: center; margin-bottom: 30px;">
+                    <button type="button" id="download-sample-csv-btn" style="background: #4CAF50; padding: 12px 25px; font-size: 14px;">
+                        📥 サンプルCSVをダウンロード
+                    </button>
+                </div>
+
                 <div class="section">
                     <h2>📊 CSVファイルからの一括生成</h2>
                     <div class="form-group">
@@ -950,9 +956,74 @@ pdf_bytes
             }
         }
 
+        function downloadSampleCSV() {
+            // サンプルCSVデータ
+            const headers = [
+                'to_postal',
+                'to_address',
+                'to_name',
+                'to_phone',
+                'to_honorific',
+                'from_postal',
+                'from_address',
+                'from_name',
+                'from_phone',
+                'from_honorific'
+            ];
+
+            const sampleRows = [
+                [
+                    '123-4567',
+                    '東京都渋谷区XXX 1-2-3 XXXビル4F',
+                    '山田 太郎',
+                    '03-1234-5678',
+                    '',
+                    '987-6543',
+                    '大阪府大阪市YYY 4-5-6',
+                    '田中 花子',
+                    '06-9876-5432',
+                    ''
+                ],
+                [
+                    '111-2222',
+                    '京都府京都市ZZZ 7-8-9',
+                    '佐藤 次郎',
+                    '075-111-2222',
+                    '様',
+                    '555-6666',
+                    '福岡県福岡市AAA 10-11-12',
+                    '鈴木 美咲',
+                    '092-555-6666',
+                    '一郎'
+                ]
+            ];
+
+            // CSVを生成
+            let csv = headers.join(',') + '\n';
+            sampleRows.forEach(row => {
+                csv += row.map(cell => {
+                    // カンマやダブルクォートを含む場合はクォートで囲む
+                    if (cell.includes(',') || cell.includes('"')) {
+                        return '"' + cell.replace(/"/g, '""') + '"';
+                    }
+                    return cell;
+                }).join(',') + '\n';
+            });
+
+            // Blobを作成してダウンロード
+            const blob = new Blob([csv], { type: 'text/csv; charset=utf-8;' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'sample.csv';
+            a.click();
+            URL.revokeObjectURL(url);
+        }
+
         // イベントリスナー設定
         document.getElementById('label-form').addEventListener('submit', generatePDF);
         document.getElementById('generate-csv-btn').addEventListener('click', generateFromCSV);
+        document.getElementById('download-sample-csv-btn').addEventListener('click', downloadSampleCSV);
 
         // ページロード時に初期化
         window.addEventListener('load', initPyodide);

--- a/src/letterpack/cli.py
+++ b/src/letterpack/cli.py
@@ -3,6 +3,7 @@
 """
 
 import argparse
+import csv
 import sys
 
 from .csv_parser import parse_csv
@@ -115,9 +116,65 @@ def main():
     # CSV一括生成
     parser.add_argument("--csv", help="CSVファイルからの一括生成（4upレイアウトで複数ページPDF）")
 
+    # サンプルCSV出力
+    parser.add_argument(
+        "--sample",
+        action="store_true",
+        help="ヘッダーとサンプル行を含むCSVを標準出力に出力",
+    )
+
     args = parser.parse_args()
 
     try:
+        # サンプルCSV出力モード
+        if args.sample:
+            # ヘッダーとサンプル行を定義
+            fieldnames = [
+                "to_postal",
+                "to_address",
+                "to_name",
+                "to_phone",
+                "to_honorific",
+                "from_postal",
+                "from_address",
+                "from_name",
+                "from_phone",
+                "from_honorific",
+            ]
+
+            sample_rows = [
+                {
+                    "to_postal": "123-4567",
+                    "to_address": "東京都渋谷区XXX 1-2-3 XXXビル4F",
+                    "to_name": "山田 太郎",
+                    "to_phone": "03-1234-5678",
+                    "to_honorific": "",
+                    "from_postal": "987-6543",
+                    "from_address": "大阪府大阪市YYY 4-5-6",
+                    "from_name": "田中 花子",
+                    "from_phone": "06-9876-5432",
+                    "from_honorific": "",
+                },
+                {
+                    "to_postal": "111-2222",
+                    "to_address": "京都府京都市ZZZ 7-8-9",
+                    "to_name": "佐藤 次郎",
+                    "to_phone": "075-111-2222",
+                    "to_honorific": "様",
+                    "from_postal": "555-6666",
+                    "from_address": "福岡県福岡市AAA 10-11-12",
+                    "from_name": "鈴木 美咲",
+                    "from_phone": "092-555-6666",
+                    "from_honorific": "一郎",
+                },
+            ]
+
+            # 標準出力にCSVを出力
+            writer = csv.DictWriter(sys.stdout, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(sample_rows)
+            return 0
+
         # CSVモード
         if args.csv:
             print("=" * 60)

--- a/src/letterpack/web.py
+++ b/src/letterpack/web.py
@@ -2,6 +2,8 @@
 Webインターフェース (Flask)
 """
 
+import csv
+import io
 import os
 import sys
 import tempfile
@@ -439,6 +441,12 @@ HTML_TEMPLATE = r"""
             <div style="margin-top: 40px; padding-top: 40px; border-top: 2px solid #e0e0e0;">
                 <h2 style="text-align: center; color: #667eea; margin-bottom: 30px;">📊 CSVファイルからの一括生成</h2>
 
+                <div style="text-align: center; margin-bottom: 30px;">
+                    <a href="{{ url_for('download_sample_csv') }}" style="display: inline-block; background: #4CAF50; color: white; padding: 12px 25px; border-radius: 6px; text-decoration: none; font-weight: 600; transition: all 0.2s;" onmouseover="this.style.background='#45a049'" onmouseout="this.style.background='#4CAF50'">
+                        📥 サンプルCSVをダウンロード
+                    </a>
+                </div>
+
                 <form method="POST" action="{{ url_for('generate_csv') }}" enctype="multipart/form-data">
                     <div class="section">
                         <h2>CSVファイルをアップロード</h2>
@@ -477,6 +485,68 @@ HTML_TEMPLATE = r"""
 def index():
     """トップページ"""
     return render_template_string(HTML_TEMPLATE)
+
+
+@app.route("/sample_csv")
+def download_sample_csv():
+    """サンプルCSVをダウンロード"""
+    # CSVデータを作成
+    fieldnames = [
+        "to_postal",
+        "to_address",
+        "to_name",
+        "to_phone",
+        "to_honorific",
+        "from_postal",
+        "from_address",
+        "from_name",
+        "from_phone",
+        "from_honorific",
+    ]
+
+    sample_rows = [
+        {
+            "to_postal": "123-4567",
+            "to_address": "東京都渋谷区XXX 1-2-3 XXXビル4F",
+            "to_name": "山田 太郎",
+            "to_phone": "03-1234-5678",
+            "to_honorific": "",
+            "from_postal": "987-6543",
+            "from_address": "大阪府大阪市YYY 4-5-6",
+            "from_name": "田中 花子",
+            "from_phone": "06-9876-5432",
+            "from_honorific": "",
+        },
+        {
+            "to_postal": "111-2222",
+            "to_address": "京都府京都市ZZZ 7-8-9",
+            "to_name": "佐藤 次郎",
+            "to_phone": "075-111-2222",
+            "to_honorific": "様",
+            "from_postal": "555-6666",
+            "from_address": "福岡県福岡市AAA 10-11-12",
+            "from_name": "鈴木 美咲",
+            "from_phone": "092-555-6666",
+            "from_honorific": "一郎",
+        },
+    ]
+
+    # メモリ内にCSVを生成
+    csv_buffer = io.StringIO()
+    writer = csv.DictWriter(csv_buffer, fieldnames=fieldnames)
+    writer.writeheader()
+    writer.writerows(sample_rows)
+
+    # メモリ内のバイナリストリームを作成
+    csv_data = csv_buffer.getvalue().encode("utf-8")
+    csv_bytes = io.BytesIO(csv_data)
+
+    return send_file(
+        csv_bytes,
+        as_attachment=True,
+        download_name="sample.csv",
+        mimetype="text/csv; charset=utf-8",
+    )
 
 
 @app.route("/generate", methods=["POST"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,55 @@
+"""
+CLIのテスト
+"""
+
+import csv
+import io
+import subprocess
+
+
+def test_cli_sample_option():
+    """--sample オプションでサンプルCSVが出力されることをテスト"""
+    # CLIをサブプロセスで実行して標準出力をキャプチャ
+    result = subprocess.run(
+        ["python", "-m", "letterpack.cli", "--sample"],
+        capture_output=True,
+        text=True,
+        cwd="/home/user/letter-pack-label-maker",
+    )
+
+    # 終了コードが0であることを確認
+    assert result.returncode == 0
+
+    # 標準出力の内容をCSVとしてパース
+    csv_reader = csv.DictReader(io.StringIO(result.stdout))
+
+    # ヘッダーの確認
+    expected_headers = [
+        "to_postal",
+        "to_address",
+        "to_name",
+        "to_phone",
+        "to_honorific",
+        "from_postal",
+        "from_address",
+        "from_name",
+        "from_phone",
+        "from_honorific",
+    ]
+    assert csv_reader.fieldnames == expected_headers
+
+    # サンプル行が2つあることを確認
+    rows = list(csv_reader)
+    assert len(rows) == 2
+
+    # 1行目のチェック
+    assert rows[0]["to_postal"] == "123-4567"
+    assert rows[0]["to_name"] == "山田 太郎"
+    assert rows[0]["from_postal"] == "987-6543"
+    assert rows[0]["from_name"] == "田中 花子"
+
+    # 2行目のチェック
+    assert rows[1]["to_postal"] == "111-2222"
+    assert rows[1]["to_name"] == "佐藤 次郎"
+    assert rows[1]["to_honorific"] == "様"
+    assert rows[1]["from_name"] == "鈴木 美咲"


### PR DESCRIPTION
- CLI: --sampleオプションでサンプルCSVを標準出力に出力
- Flask Web: /sample_csvエンドポイントでCSVダウンロード機能を追加
- 静的版HTML: downloadSampleCSV関数でブラウザ内CSVダウンロード機能を追加
- テスト: CLIの--sampleオプションをテストするtest_cli.pyを追加

ユーザーがヘッダー情報なしにCSVを作成する無茶な状況を防ぐため、
全ての形式（CLI、Web、静的版）でサンプルCSVをダウンロード可能にしました。