### PR TITLE
Fix main branch deployment workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
+        with:
+          enablement: true
 
       - name: Create deployment directory
         run: |


### PR DESCRIPTION
configure-pages アクションに enablement: true パラメータを追加し、 GitHub Pages設定を自動的に有効化するようにしました。

これにより、リポジトリ設定が自動的に構成され、
「Get Pages site failed」エラーが解決されます。