### PR TITLE
docs: CLAUDE.mdとAGENTS.mdを実装に合わせて更新

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,19 +6,47 @@
 
 **Letter Pack Label Maker** は、日本郵便のレターパック用ラベルPDFを生成するPythonツールです。
 
+### 3つのインターフェース
+
+このプロジェクトは、用途に応じて3つのインターフェースを提供しています：
+
+#### 1. CLI版（コマンドライン）
+- ターミナルから直接ラベル生成
+- 対話形式または引数指定で実行
+- CSV一括生成にも対応（4upレイアウト、複数ページ）
+- 用途：ローカル開発、バッチ処理
+
+#### 2. Webサーバー版（Flask）
+- ブラウザからフォーム入力でラベル生成
+- サーバー起動が必要（Flask）
+- Docker環境での実行を推奨（フォント統一）
+- 用途：内部ツール、サーバー環境での利用
+
+#### 3. 静的HTML版（Pyodide）⭐ 推奨
+- サーバー不要、HTMLファイルをブラウザで開くだけ
+- Pyodide（WebAssembly）でPythonをブラウザ実行
+- GitHub Pagesで公開可能
+- 完全オフライン対応（初回ロード後）
+- 用途：公開ツール、サーバーレス環境
+
 ### 主な機能
-- コマンドライン（CLI）からのラベル生成
-- Webインターフェース（Flask）からのラベル生成
+- 単一ラベル生成（CLI/Webサーバー/静的HTML）
+- CSV一括生成（4upレイアウト、複数ページ対応）
+- 敬称のカスタマイズ（様、殿、省略可能）
+- 複数エンコーディング対応（UTF-8、Shift_JIS）
 - A4サイズPDFに汎用的なTo/Fromフォーマットのラベルを出力
 
 ### 技術スタック
-- **言語**: Python 3.8.1+
+- **言語**: Python 3.8.1+（ローカル）、Python 3.12（Docker）
 - **PDF生成**: ReportLab
-- **Webフレームワーク**: Flask
+- **Webフレームワーク**: Flask（Webサーバー版）
+- **ブラウザ実行**: Pyodide 0.24.1（静的HTML版）
+- **コンテナ**: Docker / Docker Compose
 - **パッケージ管理**: uv
 - **ビルドシステム**: Hatchling
 - **リンター/フォーマッター**: Ruff
-- **テストフレームワーク**: pytest
+- **テストフレームワーク**: pytest、Playwright（静的HTML版）
+- **CI/CD**: GitHub Actions（5つのワークフロー）
 
 ## 開発環境のセットアップ
 
@@ -34,11 +62,33 @@ uv sync --all-extras
 ### プロジェクト構造
 ```
 .
-├── src/letterpack/     # メインパッケージ
-├── tests/              # テストコード
-├── examples/           # サンプル
-├── pyproject.toml      # プロジェクト設定
-└── README.md           # プロジェクト説明
+├── src/letterpack/           # メインパッケージ
+│   ├── cli.py                # CLI実装
+│   ├── csv_parser.py         # CSV処理
+│   ├── label.py              # ラベル生成ロジック
+│   └── web.py                # Flaskウェブサーバー
+├── tests/                    # テストコード
+│   ├── test_label.py         # ラベル生成のテスト
+│   ├── test_csv_parser.py    # CSV処理のテスト
+│   └── conftest.py           # pytest設定
+├── .github/workflows/        # GitHub Actionsワークフロー
+│   ├── main.yml              # PDF生成テスト
+│   ├── test-static-webui.yml # 静的WebUIテスト（Playwright）
+│   ├── deploy-pages.yml      # GitHub Pagesデプロイ
+│   ├── claude.yml            # Claude統合
+│   └── claude-code-review.yml# Claudeコードレビュー
+├── index_static.html         # 静的HTML版（本番用）
+├── poc_pyodide.html          # Pyodide PoC版
+├── examples/                 # サンプル
+├── config/                   # 設定ファイル
+├── Dockerfile                # Dockerイメージ定義
+├── docker-compose.yml        # Docker Compose設定
+├── pyproject.toml            # プロジェクト設定
+├── README.md                 # プロジェクト説明
+├── AGENTS.md                 # AIエージェント向けガイド（このファイル）
+├── CLAUDE.md                 # Claude Code固有のガイド
+├── DOCKER.md                 # Docker環境の説明
+└── STATIC_VERSION.md         # 静的HTML版の技術詳細
 ```
 
 ## コーディング規約
@@ -63,13 +113,45 @@ uv run ruff check --fix src tests
 ```
 
 ### テスト
+
+#### pytest（Pythonコード）
 ```bash
 # すべてのテストを実行
 uv run pytest
 
 # カバレッジ付きで実行
 uv run pytest --cov=letterpack --cov-report=html
+
+# 特定のテストのみ実行
+uv run pytest tests/test_label.py
+uv run pytest tests/test_csv_parser.py
 ```
+
+**テストファイル：**
+- `tests/test_label.py` - ラベル生成ロジックのテスト
+- `tests/test_csv_parser.py` - CSV処理のテスト
+- `tests/conftest.py` - pytest設定とフィクスチャ
+
+#### Playwright（静的HTML版）
+
+静的HTML版（Pyodide）は、Playwrightで自動的にブラウザテストされます：
+
+```bash
+# ローカルでPlaywrightテストを実行する場合
+npm install -D @playwright/test
+npx playwright install chromium
+python -m http.server 8888 &
+npx playwright test
+```
+
+**テスト内容：**
+- ページのロード確認
+- Pyodideの初期化（最大90秒）
+- Noto Sans JPフォントのダウンロード確認
+- フォーム要素の表示確認
+- PoC版のロード確認
+
+GitHub Actionsで自動実行されるため、通常はローカルで実行する必要はありません。
 
 ## コミットガイドライン
 
@@ -89,6 +171,117 @@ uv run pytest --cov=letterpack --cov-report=html
 - `main`: 安定版
 - 機能追加やバグ修正は別ブランチで作業し、PRを作成
 
+## デプロイメント方法
+
+このプロジェクトは、用途に応じて3つのデプロイ方法をサポートしています：
+
+### 1. ローカル開発・テスト
+
+```bash
+# CLI版で動作確認
+uv run python -m letterpack.cli
+
+# Webサーバー版で動作確認
+uv run python -m letterpack.web
+# ブラウザで http://localhost:5000 を開く
+```
+
+### 2. Docker環境（Webサーバー版）⭐ 本番推奨
+
+Docker環境を使用することで、フォント環境が統一され、一貫したPDF出力が得られます。
+
+```bash
+# Docker Composeで起動
+docker compose up -d
+
+# 環境変数を設定
+export SECRET_KEY=$(openssl rand -hex 32)
+```
+
+**メリット：**
+- フォント環境の統一（Noto CJK）
+- 依存関係の自動セットアップ
+- 本番環境での安定動作
+- ポータビリティ（Windows/Mac/Linux）
+
+詳細は `DOCKER.md` を参照してください。
+
+### 3. GitHub Pages（静的HTML版）⭐ 公開ツール推奨
+
+静的HTML版は、サーバー不要で動作し、GitHub Pagesで簡単に公開できます。
+
+**セットアップ手順：**
+1. リポジトリのSettings → Pages を開く
+2. Source を「GitHub Actions」に変更
+3. mainブランチにpushすると自動デプロイ
+
+**メリット：**
+- サーバー不要、メンテナンスフリー
+- GitHub Actionsで自動デプロイ
+- 完全無料（GitHub Pagesの範囲内）
+- オフライン対応（初回ロード後）
+- Pyodide（WebAssembly）でブラウザ内でPython実行
+
+詳細は `STATIC_VERSION.md` を参照してください。
+
+## CI/CD
+
+このプロジェクトには、5つのGitHub Actionsワークフローが設定されています：
+
+### 1. `main.yml` - PDF生成テスト
+
+- **トリガー**: mainブランチへのpush、PR作成・更新、手動実行
+- **内容**:
+  - Python 3.11をセットアップ
+  - uvで依存関係をインストール
+  - pytestを実行
+  - テストPDFを生成（`generate_test_pdf.py`）
+  - 生成されたPDFをArtifactとしてアップロード（1日保持）
+- **目的**: Pythonコードの自動テストとPDF生成の検証
+
+### 2. `test-static-webui.yml` - 静的WebUIテスト
+
+- **トリガー**: `index_static.html`, `poc_pyodide.html`, `STATIC_VERSION.md` の変更
+- **内容**:
+  - Node.js 20をセットアップ
+  - Playwrightをインストール
+  - HTTPサーバーを起動（ポート8888）
+  - Playwrightテストを実行
+    - ページのロード確認
+    - Pyodideの初期化（最大90秒）
+    - Noto Sans JP Boldフォントのダウンロード確認
+    - フォーム要素の表示確認
+    - PoC版のロード確認
+  - テスト結果をArtifactとしてアップロード（7日保持）
+- **タイムアウト**: 10分（Pyodide初期化に時間がかかるため）
+- **目的**: 静的HTML版の動作検証
+
+### 3. `deploy-pages.yml` - GitHub Pagesデプロイ
+
+- **トリガー**: mainブランチへのpush（`index_static.html`, `poc_pyodide.html`, `STATIC_VERSION.md`, `README.md` の変更時）
+- **内容**:
+  - 静的HTMLファイルをGitHub Pagesにデプロイ
+  - `index_static.html` がルート（`/`）にデプロイ
+- **公開URL**: `https://username.github.io/letter-pack-label-maker/`
+- **目的**: 静的HTML版の自動公開
+
+### 4. `claude.yml` - Claude統合
+
+- Claude Codeとの統合ワークフロー
+- Claude関連の自動化タスク
+
+### 5. `claude-code-review.yml` - Claudeコードレビュー
+
+- Claude Codeによる自動コードレビュー
+- PRに対してレビューコメントを自動投稿
+
+### CI/CDのベストプラクティス
+
+- **PRを作成する前に**: ローカルでテストとリントを実行
+- **静的HTML版を変更する場合**: ローカルでHTTPサーバーを起動して動作確認
+- **GitHub Actionsのログ**: テスト失敗時はログを確認して原因を特定
+- **Artifacts**: 生成されたPDFやテスト結果はArtifactsからダウンロード可能
+
 ## 注意事項
 
 ### 日本語対応
@@ -100,6 +293,18 @@ uv run pytest --cov=letterpack --cov-report=html
 - ReportLabを使用してPDF生成
 - A4サイズ（210mm × 297mm）に対応
 - フォントは日本語対応フォントを使用
+
+### フォント環境
+このプロジェクトは、環境によって異なるフォントを使用します：
+
+- **静的HTML版（Pyodide）**: Noto Sans JP Bold（Google Fontsから自動ダウンロード）
+- **Docker環境**: Noto Sans CJK JP、Noto Serif CJK JP（イメージに含まれる）
+- **ローカル環境**: IPA/Heiseiフォント（フォールバック）
+
+**推奨事項：**
+- 本番環境ではDocker環境を使用（フォント統一）
+- 公開ツールは静的HTML版を使用（高品質フォント）
+- ローカル開発でもフォントの違いに注意
 
 ### 文字コーディング
 - UTF-8を使用
@@ -142,7 +347,20 @@ uv sync --all-extras
 
 ## リソース
 
-- [ReportLab ドキュメント](https://www.reportlab.com/docs/)
-- [Flask ドキュメント](https://flask.palletsprojects.com/)
-- [uv ドキュメント](https://github.com/astral-sh/uv)
-- [Ruff ドキュメント](https://docs.astral.sh/ruff/)
+### 公式ドキュメント
+- [ReportLab ドキュメント](https://www.reportlab.com/docs/) - PDF生成ライブラリ
+- [Flask ドキュメント](https://flask.palletsprojects.com/) - Webフレームワーク
+- [Pyodide ドキュメント](https://pyodide.org/en/stable/) - PythonをWebAssemblyで実行
+- [Docker ドキュメント](https://docs.docker.com/) - コンテナ化
+- [GitHub Actions ドキュメント](https://docs.github.com/en/actions) - CI/CD
+- [GitHub Pages ドキュメント](https://docs.github.com/en/pages) - 静的サイトホスティング
+- [uv ドキュメント](https://github.com/astral-sh/uv) - Pythonパッケージマネージャー
+- [Ruff ドキュメント](https://docs.astral.sh/ruff/) - Pythonリンター/フォーマッター
+- [Playwright ドキュメント](https://playwright.dev/) - ブラウザ自動テスト
+
+### プロジェクト内ドキュメント
+- `README.md` - プロジェクト概要と基本的な使い方
+- `DOCKER.md` - Docker環境での実行方法
+- `STATIC_VERSION.md` - 静的HTML版の技術詳細
+- `CLAUDE.md` - Claude Code固有のガイド
+- `ISSUE_CONFIGURABLE_LAYOUT.md` - 設定可能なレイアウトの課題

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,34 @@
 
 共通のAIエージェント向けガイドラインは [AGENTS.md](./AGENTS.md) を参照してください。
 
+## プロジェクトの構成
+
+このプロジェクトは、3つのインターフェースを提供しています：
+
+### 1. CLI版（コマンドライン）
+- ターミナルから直接ラベル生成
+- 対話形式または引数指定で実行
+- CSV一括生成にも対応（4upレイアウト、複数ページ）
+- 用途：ローカル開発、バッチ処理
+
+### 2. Webサーバー版（Flask）
+- ブラウザからフォーム入力でラベル生成
+- サーバー起動が必要（Flask）
+- Docker環境での実行を推奨（フォント統一）
+- 用途：内部ツール、サーバー環境での利用
+
+### 3. 静的HTML版（Pyodide）⭐ 推奨
+- サーバー不要、HTMLファイルをブラウザで開くだけ
+- Pyodide（WebAssembly）でPythonをブラウザ実行
+- GitHub Pagesで公開可能
+- 完全オフライン対応（初回ロード後）
+- 用途：公開ツール、サーバーレス環境
+
+詳細は各ドキュメントを参照：
+- `README.md` - 全体概要と使い方
+- `DOCKER.md` - Docker環境でのWebサーバー版
+- `STATIC_VERSION.md` - 静的HTML版の技術詳細
+
 ## Claude Code固有の設定
 
 ### プロジェクトのセットアップ
@@ -36,6 +64,11 @@ uv run pytest
 4. **コミット**
    - 明確なコミットメッセージで変更をコミット
    - 複数の関連する変更は1つのコミットにまとめる
+
+5. **GitHub Actionsとの統合**
+   - PRを作成すると自動的にテストが実行される（`.github/workflows/main.yml`）
+   - 静的HTML版を変更すると自動的にPlaywrightテストが実行される（`.github/workflows/test-static-webui.yml`）
+   - mainブランチにマージすると自動的にGitHub Pagesにデプロイされる（`.github/workflows/deploy-pages.yml`）
 
 ## Claude Codeの得意な作業
 
@@ -70,15 +103,19 @@ uv run pytest
 
 ### 新機能の追加
 
-**例: 品名フィールドの追加**
+**例: 予定機能の実装（品名フィールドなど）**
+
+品名フィールドは `ISSUE_CONFIGURABLE_LAYOUT.md` に記載されている予定機能です。実装する場合：
 
 1. 仕様を確認・質問
    - レターパックのどこに表示するか？
    - 入力形式は？（自由記述？選択式？）
+   - 3つのインターフェース（CLI、Webサーバー、静的HTML）すべてに実装するか？
 
 2. 実装計画
-   - データモデルの変更が必要か確認
-   - CLI、Web両方に影響があるか確認
+   - データモデルの変更が必要か確認（`src/letterpack/label.py`）
+   - CLI、Webサーバー、静的HTML版すべてに影響があるか確認
+   - テストケースの追加が必要か確認
 
 3. 実装
    ```bash
@@ -144,6 +181,143 @@ uv run python -m letterpack.web
 - テストを書いて問題を再現
 - ReportLabのドキュメントを参照（PDF生成関連の問題の場合）
 
+## テストとCI/CD
+
+### テストフレームワーク
+
+このプロジェクトは、2種類のテストを実施しています：
+
+#### 1. pytest（Pythonコード）
+```bash
+# すべてのテストを実行
+uv run pytest
+
+# カバレッジ付きで実行
+uv run pytest --cov=letterpack --cov-report=html
+
+# 特定のテストのみ実行
+uv run pytest tests/test_label.py
+uv run pytest tests/test_csv_parser.py
+```
+
+**テストファイル：**
+- `tests/test_label.py` - ラベル生成ロジックのテスト
+- `tests/test_csv_parser.py` - CSV処理のテスト
+- `tests/conftest.py` - pytest設定とフィクスチャ
+
+#### 2. Playwright（静的HTML版）
+静的HTML版（Pyodide）は、Playwrightで自動テストされます：
+
+```bash
+# ローカルでPlaywrightテストを実行する場合
+npm install -D @playwright/test
+npx playwright install chromium
+python -m http.server 8888 &
+npx playwright test
+```
+
+**テスト内容：**
+- Pyodideの初期化（最大90秒）
+- Noto Sans JPフォントのダウンロード確認
+- フォーム要素の表示確認
+- PoC版のロード確認
+
+### GitHub Actionsワークフロー
+
+プロジェクトには5つのワークフローが設定されています：
+
+#### 1. `main.yml` - PDF生成テスト
+- **トリガー**: mainブランチへのpush、PR作成・更新
+- **内容**: pytestを実行し、テストPDFを生成
+- **成果物**: 生成されたPDFをArtifactとしてダウンロード可能（1日保持）
+
+#### 2. `test-static-webui.yml` - 静的WebUIテスト
+- **トリガー**: `index_static.html`, `poc_pyodide.html`, `STATIC_VERSION.md` の変更
+- **内容**: Playwrightでブラウザテスト実行
+- **タイムアウト**: 10分（Pyodide初期化に時間がかかるため）
+
+#### 3. `deploy-pages.yml` - GitHub Pagesデプロイ
+- **トリガー**: mainブランチへのpush
+- **内容**: 静的HTML版をGitHub Pagesに自動デプロイ
+- **公開URL**: `https://username.github.io/letter-pack-label-maker/`
+
+#### 4. `claude.yml` - Claude統合
+- Claude Codeとの統合ワークフロー
+
+#### 5. `claude-code-review.yml` - Claudeコードレビュー
+- Claude Codeによる自動コードレビュー
+
+### CI/CDベストプラクティス
+
+- PRを作成する前に、ローカルでテストとリントを実行
+- 静的HTML版を変更する場合は、ローカルでHTTPサーバーを起動して動作確認
+- GitHub Actionsのログを確認して、テスト失敗の原因を特定
+
+## フォント戦略
+
+このプロジェクトは、環境によって異なるフォントを使用します：
+
+### 1. 静的HTML版（Pyodide）
+- **Noto Sans JP Bold** - Google Fontsから自動ダウンロード（約2MB）
+- JavaScriptでフォントをダウンロードし、Pyodideの仮想ファイルシステムに保存
+- 高品質な日本語フォント、商用利用可能
+
+### 2. Docker環境（Webサーバー版）
+- **Noto Sans CJK JP** - ゴシック体（Dockerイメージに含まれる）
+- **Noto Serif CJK JP** - 明朝体（Dockerイメージに含まれる）
+- フォント環境が統一され、どの環境でも一貫したPDF出力
+
+### 3. ローカル環境（CLI、Webサーバー版）
+- **IPA/Heiseiフォント** - ReportLabのCJKフォント（フォールバック）
+- **Helvetica** - 最終フォールバック（日本語非対応）
+- 環境に依存するため、Dockerの使用を推奨
+
+### フォント選択のポイント
+- **本番環境**: Docker環境を使用（Noto CJK）
+- **公開ツール**: 静的HTML版を使用（Noto Sans JP）
+- **開発環境**: ローカル環境でも動作するが、フォントが異なる可能性あり
+
+## デプロイメント戦略
+
+### 使い分けガイド
+
+#### 1. ローカル開発・テスト
+```bash
+# CLI版で動作確認
+uv run python -m letterpack.cli
+
+# Webサーバー版で動作確認
+uv run python -m letterpack.web
+```
+
+#### 2. 本番環境（Webサーバー版）
+Docker環境の使用を推奨（`DOCKER.md` 参照）：
+```bash
+# Docker Composeで起動
+docker compose up -d
+
+# 環境変数を設定
+export SECRET_KEY=$(openssl rand -hex 32)
+```
+
+**推奨理由：**
+- フォント環境の統一
+- 依存関係の自動セットアップ
+- 本番環境での安定動作
+
+#### 3. 公開ツール（静的HTML版）⭐ 推奨
+GitHub Pagesでの公開が最も簡単（`STATIC_VERSION.md` 参照）：
+
+1. リポジトリのSettings → Pages を開く
+2. Source を「GitHub Actions」に変更
+3. mainブランチにpushすると自動デプロイ
+
+**推奨理由：**
+- サーバー不要、メンテナンスフリー
+- GitHub Actionsで自動デプロイ
+- 完全無料（GitHub Pagesの範囲内）
+- オフライン対応（初回ロード後）
+
 ## Claude Codeの制限事項
 
 ### できないこと
@@ -174,10 +348,21 @@ Claude Codeでこのプロジェクトに取り組む際は：
 
 1. **AGENTS.md**で共通のガイドラインを確認
 2. **このファイル**でClaude Code固有の設定を確認
-3. **README.md**でプロジェクトの使い方を理解
-4. **pyproject.toml**で依存関係と設定を確認
-5. 実装前に必要なファイルを読む
-6. 変更後は必ずテストとリントを実行
-7. 不明点はユーザーに質問
+3. **プロジェクトの構成**を理解（CLI/Webサーバー/静的HTML版）
+4. **README.md**でプロジェクトの使い方を理解
+5. **pyproject.toml**で依存関係と設定を確認
+6. 実装前に必要なファイルを読む
+7. 変更後は必ずテストとリントを実行
+8. **GitHub Actionsで自動テスト**が実行されることを確認
+9. **デプロイメント戦略**を理解（Docker/GitHub Pages）
+10. 不明点はユーザーに質問
 
-Happy coding! 🚀
+### クイックリファレンス
+
+- **ローカル開発**: `uv run pytest` → `uv run ruff check --fix src tests`
+- **Docker環境**: `docker compose up -d`
+- **静的HTML版**: GitHub Pagesで自動デプロイ
+- **フォント**: 静的HTML版（Noto Sans JP）、Docker（Noto CJK）、ローカル（IPA/Heiseiフォント）
+- **CI/CD**: 5つのGitHub Actionsワークフロー（pytest、Playwright、デプロイ、Claude統合）
+
+Happy coding!


### PR DESCRIPTION
## 概要

CLAUDE.mdとAGENTS.mdを、現在の実装内容に合わせて更新しました。特に静的HTML版（Pyodide）、Docker環境、GitHub Actions自動デプロイなど、実装済みだがドキュメントに記載されていなかった機能を追加しました。

## 変更内容

### 必須修正（実装との乖離を解消）

1. **静的HTML版（Pyodide）の追加**
   - サーバー不要のブラウザ版、GitHub Pages対応について説明
   - Pyodide（WebAssembly）によるブラウザ内Python実行の詳細

2. **CSV一括生成機能の追加**
   - 4upレイアウト、複数ページ対応の機能説明
   - 敬称カスタマイズ、複数エンコーディング対応

3. **Docker環境の追加**
   - フォント統一、本番環境での推奨事項
   - Docker Composeによる簡単な起動方法

4. **GitHub Actions自動デプロイの追加**
   - 5つのワークフローの詳細説明（PDF生成テスト、静的WebUIテスト、GitHub Pagesデプロイ、Claude統合、コードレビュー）
   - CI/CDパイプラインの全体像

5. **品名フィールドの記述修正**
   - 「実装例」→「予定機能」に変更（`ISSUE_CONFIGURABLE_LAYOUT.md`参照）

### Nice to have改善

6. **3つのインターフェースの特徴と使い分け**
   - CLI/Webサーバー/静的HTMLの用途別ガイド
   - それぞれのメリット・デメリット

7. **デプロイメント戦略**
   - ローカル/Docker/GitHub Pagesの使い分けガイド
   - 環境別の推奨事項

8. **テスト戦略**
   - pytest（Pythonコード）とPlaywright（静的HTML版）の詳細
   - テストファイルの構成

9. **フォント戦略**
   - Noto Sans JP（静的版）、Noto CJK（Docker）、IPA/Heiseiフォント（ローカル）
   - 環境別フォント選択のポイント

## 動機/背景

プロジェクトが成長し、以下の機能が実装されていましたが、CLAUDE.mdとAGENTS.mdに反映されていませんでした：
- 静的HTML版（Pyodide）による完全サーバーレス対応
- GitHub Pagesでの自動デプロイ
- Docker環境によるフォント統一
- Playwrightによる自動ブラウザテスト

これらのドキュメント更新により、AIエージェント（特にClaude Code）がプロジェクトを正しく理解し、適切なサポートを提供できるようになります。

## テスト

- [x] CLAUDE.mdの内容を確認
- [x] AGENTS.mdの内容を確認
- [x] README.md、DOCKER.md、STATIC_VERSION.mdとの整合性を確認
- [x] プロジェクト構造の記載が正確であることを確認

## 影響範囲

- ドキュメントのみの変更
- コード変更なし
- 既存機能への影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)