### PR TITLE
test: GitHub Actions環境でのtest_cli_sample_option失敗を修正

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,6 @@ def test_cli_sample_option():
         ["python", "-m", "letterpack.cli", "--sample"],
         capture_output=True,
         text=True,
-        cwd="/home/user/letter-pack-label-maker",
     )
 
     # 終了コードが0であることを確認


### PR DESCRIPTION
## Summary
- `tests/test_cli.py` のハードコードされた `cwd` パラメータを削除し、GitHub Actions環境でのテスト失敗を修正

## 問題
- `test_cli_sample_option` テストで `cwd="/home/user/letter-pack-label-maker"` がハードコードされていた
- このパスはGitHub Actions環境では存在せず、テストが `FileNotFoundError` で失敗していた
- エラーログ: https://github.com/ebal5/letter-pack-label-maker/actions/runs/19305132909

## 修正内容
- `subprocess.run()` から `cwd` パラメータを削除
- pytestはプロジェクトのルートディレクトリから実行されるため、`cwd` パラメータは不要
- この変更により、ローカル環境でもGitHub Actions環境でも動作するようになる

## Test plan
- [x] ローカルで `uv run pytest tests/test_cli.py::test_cli_sample_option -v` を実行し、テストがパスすることを確認
- [x] すべてのテスト (`uv run pytest -v`) が正常に動作することを確認
- [x] Ruffでコードチェックとフォーマットを実行し、問題がないことを確認
- [ ] GitHub Actionsでテストが正常に動作することを確認（PRマージ後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)