### PR TITLE
Adjust sender section layout and spacing

### DIFF
--- a/src/letterpack/label.py
+++ b/src/letterpack/label.py
@@ -558,6 +558,8 @@ class LabelGenerator:
         current_y = y + height - margin_top
 
         label_font_size = int(self.config.fonts.label * font_scale)
+        # 郵便番号マーク（〒記号）は常に固定サイズ（font_scaleを適用しない）
+        postal_mark_font_size = self.config.fonts.label
         # 送り主セクションの場合は住所フォントサイズを調整
         if is_from_section:
             address_font_size = int(
@@ -590,7 +592,7 @@ class LabelGenerator:
         dotted_line_text_offset = self.config.spacing.dotted_line_text_offset
 
         # 郵便番号（〒記号付き）
-        c.setFont(self.font_name, label_font_size)
+        c.setFont(self.font_name, postal_mark_font_size)
         c.setFillColorRGB(0, 0, 0)
         postal_y = current_y  # 〒記号の位置を記録
         c.drawString(x + margin_left, postal_y, "〒")


### PR DESCRIPTION
送り主セクションに限定した以下の修正を実施：
- 住所行数を3行から2行に制限
- 住所と名前の間のマージンを27pxから9px (1/3) に減少
- 名前と電話番号のマージンを36pxから12px (1/3) に減少
- 住所のフォントサイズを11ptから13pt (+2pt) に増加

変更内容：
- SectionHeightConfigに送り主セクション専用の設定を追加
  - from_address_max_lines: 住所の最大行数 (2)
  - from_address_name_gap: 住所と名前の間隔 (9px)
  - from_name_phone_gap: 名前と電話番号の間隔 (12px)
  - from_address_font_size_adjust: 住所フォントサイズ調整 (+2pt)
- _draw_address_sectionメソッドを修正し、送り主セクションの判定を追加
- 送り主セクションの場合のみ専用設定を適用

お届け先セクションは既存の設定を維持し、影響なし。